### PR TITLE
H toggles video overlay

### DIFF
--- a/src/renderer/pages/App.tsx
+++ b/src/renderer/pages/App.tsx
@@ -49,6 +49,9 @@ import NavLink from '../components/NavLink/NavLink';
 export default function App() {
   const addVideo = useVideoStore((state) => state.addVideo);
   const clearVideos = useVideoStore((state) => state.clearVideos);
+  const overrideHideControls = useVideoStore(
+    (state) => state.overrideHideControls
+  );
 
   const setShownFirstHelpReview = useSettingsStore(
     (state) => state.setShownFirstHelpReview
@@ -198,7 +201,7 @@ export default function App() {
                 <Td>
                   <Kbd>H</Kbd>
                 </Td>
-                <Td>Hold to hide controls</Td>
+                <Td>Toggles the video overlay on and off</Td>
               </Tr>
               <Tr>
                 <Td>
@@ -279,11 +282,18 @@ export default function App() {
                 <NavLink to="/about">About</NavLink>
               </Flex>
               <Spacer />
-              {showHelpButton === true && (
-                <Button leftIcon={<HelpIcon />} onClick={() => onOpen()}>
-                  Help
-                </Button>
-              )}
+              <Flex align="center">
+                {overrideHideControls === true && (
+                  <Text fontSize="sm" mr={4}>
+                    Video overlays hidden
+                  </Text>
+                )}
+                {showHelpButton === true && (
+                  <Button leftIcon={<HelpIcon />} onClick={() => onOpen()}>
+                    Help
+                  </Button>
+                )}
+              </Flex>
             </Flex>
             <Flex as="main" height="calc(100vh - 5rem)" overflow="hidden">
               <Outlet />

--- a/src/renderer/pages/ReviewVideos.tsx
+++ b/src/renderer/pages/ReviewVideos.tsx
@@ -399,7 +399,9 @@ export default function ReviewVideos() {
     };
   }, [mouseLastActive, setMouseLastActive]);
 
-  // When changing between active videos, show the controls for some time
+  /**
+   * When changing between active videos, show the controls for some time
+   */
   useEffect(() => {
     setPlayerHeaderOn(true);
 
@@ -413,6 +415,16 @@ export default function ReviewVideos() {
       clearInterval(timer);
     };
   }, [activeVideoId, setPlayerHeaderOn]);
+
+  /**
+   * When toggling the override hide off, set the mouse being active to toggle
+   * on the controls.
+   */
+  useEffect(() => {
+    if (overrideHideControls === false) {
+      setMouseLastActive(Date.now());
+    }
+  }, [overrideHideControls, setMouseLastActive]);
 
   /**
    * The scale of how much the current video has been reduced in size. If no

--- a/src/renderer/pages/ReviewVideos/Hotkeys.tsx
+++ b/src/renderer/pages/ReviewVideos/Hotkeys.tsx
@@ -30,6 +30,9 @@ export default function HotKeys({
   const currentTime = useVideoStore((state) => state.currentTime);
   const playing = useVideoStore((state) => state.playing);
   const videos = useVideoStore((state) => state.videos);
+  const overrideHideControls = useVideoStore(
+    (state) => state.overrideHideControls
+  );
 
   const arrowKeyJumpDistance = useSettingsStore(
     (state) => state.arrowKeyJumpDistance
@@ -312,31 +315,19 @@ export default function HotKeys({
   );
 
   /**
-   * Holding H
+   * Press H
    */
   useHotkeys(
     'h',
     () => {
-      setOverrideHideControls(true);
+      if (overrideHideControls === true) {
+        setOverrideHideControls(false);
+      } else {
+        setOverrideHideControls(true);
+      }
     },
-    {
-      keydown: true,
-    },
-    [previousFrameHeld, currentTime]
-  );
-
-  /**
-   * Let go of H
-   */
-  useHotkeys(
-    'h',
-    () => {
-      setOverrideHideControls(false);
-    },
-    {
-      keyup: true,
-    },
-    [previousFrameHeld, currentTime]
+    {},
+    [overrideHideControls]
   );
 
   return <></>;


### PR DESCRIPTION
Changes the `H` hotkey behaviour to toggle hiding UI components rather than needing to be held down.

Fixes: https://github.com/Rodeoclash/vodon-pro/issues/60